### PR TITLE
"as-is" DS402-based task for Roboteq controller

### DIFF
--- a/motors_roboteq_canopen.orogen
+++ b/motors_roboteq_canopen.orogen
@@ -41,5 +41,5 @@ task_context 'Task', subclasses: 'canopen_master::SlaveTask' do
     # The joint state
     output_port 'joint_samples', '/base/samples/Joints'
 
-    port_driven
+    port_driven :can_in, :joint_cmd
 end

--- a/motors_roboteq_canopen.orogen
+++ b/motors_roboteq_canopen.orogen
@@ -35,9 +35,6 @@ task_context 'Task', subclasses: 'canopen_master::SlaveTask' do
     property 'state_change_timeout',
              '/base/Time'
 
-    # CAN messages coming from the device
-    input_port 'can_messages', 'canbus/Message'
-
     # The desired commands
     input_port 'joint_cmd', '/base/commands/Joints'
 

--- a/motors_roboteq_canopen.orogen
+++ b/motors_roboteq_canopen.orogen
@@ -12,14 +12,14 @@ using_task_library 'canopen_master'
 using_library 'motors_roboteq_canopen'
 import_types_from 'motors_roboteq_canopenTypes.hpp'
 
-task_context 'Task', subclasses: 'canopen_master::SlaveTask' do
+task_context 'DS402Task', subclasses: 'canopen_master::SlaveTask' do
     needs_configuration
 
     # Channel configurations, starting at channel 0
     #
     # Channels with operation_mode set to OPERATION_MODE_NONE are ignored
     property 'channel_configurations',
-             '/std/vector</motors_roboteq_canopen/ChannelConfiguration>'
+             '/std/vector</motors_roboteq_canopen/DS402ChannelConfiguration>'
 
     # Configuration parameters regarding receiving joint states
     property 'joint_state_settings',

--- a/motors_roboteq_canopenTypes.hpp
+++ b/motors_roboteq_canopenTypes.hpp
@@ -9,8 +9,8 @@ namespace motors_roboteq_canopen {
      *
      * Channels with operation_mode set to OPERATION_MODE_NONE are ignored
      */
-    struct ChannelConfiguration {
-        OperationModes operation_mode = OPERATION_MODE_NONE;
+    struct DS402ChannelConfiguration {
+        DS402OperationModes operation_mode = DS402_OPERATION_MODE_NONE;
         Factors factors;
     };
 }

--- a/tasks/DS402Task.hpp
+++ b/tasks/DS402Task.hpp
@@ -1,10 +1,10 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
 
-#ifndef MOTORS_ROBOTEQ_CANOPEN_TASK_TASK_HPP
-#define MOTORS_ROBOTEQ_CANOPEN_TASK_TASK_HPP
+#ifndef MOTORS_ROBOTEQ_CANOPEN_TASK_DS402TASK_HPP
+#define MOTORS_ROBOTEQ_CANOPEN_TASK_DS402TASK_HPP
 
-#include "motors_roboteq_canopen/TaskBase.hpp"
-#include <motors_roboteq_canopen/Driver.hpp>
+#include "motors_roboteq_canopen/DS402TaskBase.hpp"
+#include <motors_roboteq_canopen/DS402Driver.hpp>
 
 namespace motors_roboteq_canopen{
 
@@ -22,17 +22,17 @@ namespace motors_roboteq_canopen{
      \endverbatim
      *  It can be dynamically adapted when the deployment is called with a prefix argument.
      */
-    class Task : public TaskBase
+    class DS402Task : public DS402TaskBase
     {
-	friend class TaskBase;
+	friend class DS402TaskBase;
     protected:
         canopen_master::StateMachine* m_state_machine = nullptr;
-        Driver* m_driver = nullptr;
+        DS402Driver* m_driver = nullptr;
         int m_channel_count = 0;
         std::vector<bool> m_channel_ignored;
         base::samples::Joints m_joint_state;
 
-        void waitDS402State(Channel& channel, StatusWord::State state);
+        void waitDS402State(DS402Channel& channel, StatusWord::State state);
         void channelsToSwitchOnDisabled();
         void channelsToSwitchOn();
 
@@ -41,11 +41,11 @@ namespace motors_roboteq_canopen{
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
          * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
          */
-        Task(std::string const& name = "motors_roboteq_canopen::Task");
+        DS402Task(std::string const& name = "motors_roboteq_canopen::DS402Task");
 
         /** Default deconstructor of Task
          */
-	~Task();
+        ~DS402Task();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -114,6 +114,15 @@ void Task::updateHook()
         m_driver->process(msg);
     }
 
+    base::samples::Joints command;
+    while (_joint_cmd.read(command, false) == RTT::NewData) {
+        m_driver->setJointCommand(command);
+        auto const& messages = m_driver->getRPDOMessages();
+        for (auto const& msg : messages) {
+            _can_out.write(msg);
+        }
+    }
+
     bool has_update = true;
     for (int i = 0; i < m_channel_count; ++i) {
         auto& channel = m_driver->getChannel(i);

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -126,6 +126,7 @@ void Task::updateHook()
     }
 
     if (has_update) {
+        _joint_samples.write(m_joint_state);
         for (int i = 0; i < m_channel_count; ++i) {
             m_driver->getChannel(i).resetJointStateTracking();
         }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -193,11 +193,11 @@ void Task::channelsToSwitchOnDisabled() {
             case StatusWord::SWITCH_ON_DISABLED:
                 break;
             case StatusWord::NOT_READY_TO_SWITCH_ON:
-                waitDS402State(channel, StatusWord::READY_TO_SWITCH_ON);
             case StatusWord::READY_TO_SWITCH_ON:
             case StatusWord::SWITCH_ON:
             case StatusWord::OPERATION_ENABLED:
-                writeSDOs(channel.sendDS402Transition(ControlWord::DISABLE_VOLTAGE, false));
+                writeSDOs(channel.
+                          sendDS402Transition(ControlWord::DISABLE_VOLTAGE, false));
                 break;
             case StatusWord::QUICK_STOP_ACTIVE:
                 waitDS402State(channel, StatusWord::SWITCH_ON_DISABLED);
@@ -221,13 +221,10 @@ void Task::channelsToSwitchOn() {
                 waitDS402State(channel, StatusWord::FAULT);
             case StatusWord::FAULT:
                 writeSDOs(channel.sendDS402Transition(ControlWord::FAULT_RESET, false));
+            case StatusWord::NOT_READY_TO_SWITCH_ON:
             case StatusWord::SWITCH_ON_DISABLED:
                 writeSDOs(channel.sendDS402Transition(ControlWord::SHUTDOWN, false));
             case StatusWord::READY_TO_SWITCH_ON:
-                writeSDOs(channel.sendDS402Transition(ControlWord::SWITCH_ON, false));
-                break;
-            case StatusWord::NOT_READY_TO_SWITCH_ON:
-                waitDS402State(channel, StatusWord::READY_TO_SWITCH_ON);
                 writeSDOs(channel.sendDS402Transition(ControlWord::SWITCH_ON, false));
                 break;
             case StatusWord::SWITCH_ON:


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-motors_roboteq_canopen/pull/3

This is the final state of the driver based on CANOpen's DS402 profile. Either my understanding of the standard is totally wrong, or Roboteq's implementation is either super buggy or (more likely) depends on the usage of a proper encoder.

This latter point is IMO the most likely: it appears that the roboteq controllers have this "low level" mode of sorts when using analog feedback, where the feedback is not converted to an actual speed/position value. The PID works on the normalized analog value and output PWMs and that's it. This just doesn't play very well with the DS402 profile which standardizes on actual physical values. I managed to get the velocity control mode to generate something (control around zero), but could not change the target value (it was stuck to zero).

The tests pass, but it's really "as-is" to keep it around. I'll start again, this time aiming at using the Roboteq-specific CANOpen objects.