### PR TITLE
output the controller status flags

### DIFF
--- a/motors_roboteq_canopen.orogen
+++ b/motors_roboteq_canopen.orogen
@@ -12,6 +12,7 @@ using_task_library "canopen_master"
 
 using_library "motors_roboteq_canopen"
 import_types_from "motors_roboteq_canopenTypes.hpp"
+import_types_from "motors_roboteq_canopen/ControllerStatus.hpp"
 
 # Controller driver that uses Roboteq's own CANOpen dictionary
 task_context "Task", subclasses: "canopen_master::SlaveTask" do
@@ -35,11 +36,18 @@ task_context "Task", subclasses: "canopen_master::SlaveTask" do
     property "analog_input_settings",
              "/canopen_master/PDOCommunicationParameters"
 
+    # Configuration parameters regarding receiving joint states
+    property "status_settings",
+             "/canopen_master/PDOCommunicationParameters"
+
     # The desired commands
     input_port "joint_cmd", "/base/commands/Joints"
 
     # The joint state
     output_port "joint_samples", "/base/samples/Joints"
+
+    # The controller status
+    output_port "controller_status", "/motors_roboteq_canopen/ControllerStatus"
 
     # The analog inputs
     output_port "analog_inputs", "/std/vector</raw_io/Analog>"

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -73,7 +73,8 @@ bool Task::configureHook() {
 
     vector<canbus::Message> tpdo_setup;
     int pdoIndex = m_driver->setupJointStateTPDOs(tpdo_setup, 0, _joint_state_settings.get());
-    m_driver->setupAnalogTPDOs(tpdo_setup, pdoIndex, _analog_input_settings.get());
+    pdoIndex = m_driver->setupAnalogTPDOs(tpdo_setup, pdoIndex, _analog_input_settings.get());
+    m_driver->setupStatusTPDOs(tpdo_setup, pdoIndex, _status_settings.get());
     writeSDOs(tpdo_setup);
 
     return true;
@@ -114,6 +115,11 @@ void Task::updateHook()
 
     m_joint_state.time = base::Time::now();
     _joint_samples.write(m_joint_state);
+    try {
+        _controller_status.write(m_driver->getControllerStatus());
+    }
+    catch(canopen_master::ObjectNotRead&) {
+    }
     for (size_t i = 0; i < m_driver->getChannelCount(); ++i) {
         m_driver->getChannel(i).resetJointStateTracking();
     }


### PR DESCRIPTION
Note that this goes into a "tupan" branch, as this setup is *very* specific
to our (Tidewise's) use case. The driver uses one PDO per channel
(we use only one) plus two for the status, and we only need one
analog input (half of a PDO).

Anything more demanding won't configure as it would need more PDOs.
The configuration interface would need to be updated to allow
selecting which analogs go in PDOs, and the controller status should
be using SDOs for low-priority values (e.g. voltages and temperatures)