### PR TITLE
feat: make the use of PDOs for status optional

### DIFF
--- a/motors_roboteq_canopen.orogen
+++ b/motors_roboteq_canopen.orogen
@@ -40,6 +40,17 @@ task_context "Task", subclasses: "canopen_master::SlaveTask" do
     property "status_settings",
              "/canopen_master/PDOCommunicationParameters"
 
+    # Whether the status output should use PDOs (device-triggered outputs)
+    # or direct queries
+    #
+    # The amount of available PDOs is limited. Disable this if you want to use
+    # more than one channel
+    property "status_use_pdo", "bool", true
+
+    # When status_use_pdo is false, this defines the period at which the status will
+    # be queried. The default is 5s
+    property "status_query_period", "base/Time"
+
     # The desired commands
     input_port "joint_cmd", "/base/commands/Joints"
 

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -33,6 +33,9 @@ namespace motors_roboteq_canopen{
         std::vector<raw_io::Analog> m_analog_inputs;
         void outputAnalog();
 
+        base::Time m_status_query_deadline;
+        void handleStatus();
+
     public:
         /** TaskContext constructor for Task
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.


### PR DESCRIPTION
They take 2 PDOs, which are better used for other channels if there is more than one channel.
