### PR TITLE
fix: read status little by little

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -195,6 +195,8 @@ void Task::errorHook()
 }
 void Task::stopHook()
 {
+    readSDOs(m_driver->queryControllerStatus());
+    writeStatusPort();
     writeSDOs(m_driver->queryMotorStop());
     TaskBase::stopHook();
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -34,7 +34,10 @@ namespace motors_roboteq_canopen{
         void outputAnalog();
 
         base::Time m_status_query_deadline;
-        void handleStatus();
+        std::vector<canbus::Message> m_status_sdos;
+
+        void handleStatusQuery();
+        void writeStatusPort();
 
     public:
         /** TaskContext constructor for Task


### PR DESCRIPTION
# What is this PR for

To be able to control more than one motor channel, we implemented reading the controller status using
SDOs instead of PDOs in #6. However, reading the status this way takes ~1.2s on our system, which leads
to actually interrupting the motor control.

This commit tries to work around the problem by reading the SDOs one by one. However, we still have to
evaluate the impact it has on control frequency.

# Results, How I tested

Currently untested (this is why it is marked as DO NOT MERGE)

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
