### PR TITLE
feat: add feedback timeout

### DIFF
--- a/motors_roboteq_canopen.orogen
+++ b/motors_roboteq_canopen.orogen
@@ -51,6 +51,9 @@ task_context "Task", subclasses: "canopen_master::SlaveTask" do
     # be queried. The default is 5s
     property "status_query_period", "base/Time"
 
+    # How long the task will wait for a feedback until it enters an exception state
+    property "feedback_timeout", "/base/Time"
+
     # The desired commands
     input_port "joint_cmd", "/base/commands/Joints"
 
@@ -62,6 +65,8 @@ task_context "Task", subclasses: "canopen_master::SlaveTask" do
 
     # The analog inputs
     output_port "analog_inputs", "/std/vector</raw_io/Analog>"
+
+    exception_states :FEEDBACK_TIMEOUT
 
     port_driven :can_in, :joint_cmd
 end

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -36,6 +36,8 @@ bool Task::configureHook() {
         return false;
     }
 
+    m_feedback_timeout = _feedback_timeout.get();
+
     // The Roboteq firmware does not send the Boot-up message on RESET,
     // so we can't guard this state transition
     //
@@ -90,10 +92,16 @@ bool Task::startHook()
     }
 
     m_status_query_deadline = base::Time();
+    m_feedback_deadline = base::Time::now() + m_feedback_timeout;
+
     return true;
 }
 void Task::updateHook()
 {
+    if (base::Time::now() > m_feedback_deadline) {
+        return exception(FEEDBACK_TIMEOUT);
+    }
+
     canbus::Message msg;
     while (_can_in.read(msg, false) == RTT::NewData) {
         m_driver->process(msg);
@@ -117,6 +125,7 @@ void Task::updateHook()
             has_update = false;
             break;
         }
+        m_feedback_deadline = base::Time::now() + m_feedback_timeout;
 
         m_joint_state.elements[i] = channel.getJointState();
     }
@@ -127,6 +136,7 @@ void Task::updateHook()
 
     m_joint_state.time = base::Time::now();
     _joint_samples.write(m_joint_state);
+
     for (size_t i = 0; i < m_driver->getChannelCount(); ++i) {
         m_driver->getChannel(i).resetJointStateTracking();
     }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -9,6 +9,7 @@ using namespace motors_roboteq_canopen;
 Task::Task(std::string const& name)
     : TaskBase(name) {
     _status_query_period.set(base::Time::fromSeconds(5));
+    _feedback_timeout.set(base::Time::fromSeconds(1));
 }
 
 Task::~Task() {

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -31,6 +31,17 @@ namespace motors_roboteq_canopen{
         base::samples::Joints m_joint_state;
 
         std::vector<raw_io::Analog> m_analog_inputs;
+
+        /**
+         * @brief The feedback deadline
+         */
+        base::Time m_feedback_deadline;
+
+        /**
+         * @brief The feedback timeout
+         */
+        base::Time m_feedback_timeout;
+
         void outputAnalog();
 
         base::Time m_status_query_deadline;


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
Add timeout to roboteq driver
The intention is that it enter in exception state when the roboteq loses power
[sc-58276]

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
