### PR TITLE
feat: input timeout

### DIFF
--- a/motors_roboteq_canopen.orogen
+++ b/motors_roboteq_canopen.orogen
@@ -40,6 +40,9 @@ task_context "Task", subclasses: "canopen_master::SlaveTask" do
     property "status_settings",
              "/canopen_master/PDOCommunicationParameters"
 
+    # Timeout which the controller will issue a stop command when no input (joint_cmd)
+    property "input_timeout", "base/Time"
+
     # Whether the status output should use PDOs (device-triggered outputs)
     # or direct queries
     #
@@ -66,9 +69,10 @@ task_context "Task", subclasses: "canopen_master::SlaveTask" do
     # The analog inputs
     output_port "analog_inputs", "/std/vector</raw_io/Analog>"
 
+    runtime_states "INPUT_TIMEOUT"
     exception_states :FEEDBACK_TIMEOUT
 
-    port_driven :can_in, :joint_cmd
+    periodic 0.1
 end
 
 # Controller driver that uses the DS402 profile

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -106,6 +106,8 @@ bool Task::startHook()
 }
 void Task::updateHook()
 {
+    TaskBase::updateHook();
+
     if (base::Time::now() > m_feedback_deadline) {
         return exception(FEEDBACK_TIMEOUT);
     }
@@ -165,8 +167,6 @@ void Task::updateHook()
             state(RUNNING);
         }
     }
-
-    TaskBase::updateHook();
 }
 
 void Task::handleStatusQuery()

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -11,6 +11,7 @@ Task::Task(std::string const& name)
 {
     _status_query_period.set(base::Time::fromSeconds(5));
     _feedback_timeout.set(base::Time::fromSeconds(1));
+    _input_timeout.set(base::Time::fromSeconds(1));
 }
 
 Task::~Task()
@@ -30,6 +31,8 @@ bool Task::configureHook()
         LOG_ERROR_S << "no channels configured" << std::endl;
         return false;
     }
+
+    m_input_timeout = _input_timeout.get();
 
     m_state_machine = new canopen_master::StateMachine(_node_id.get());
     m_driver = new Driver(*m_state_machine, channel_configurations.size());
@@ -89,7 +92,6 @@ bool Task::configureHook()
     writeSDOs(tpdo_setup);
 
     return true;
-
 }
 bool Task::startHook()
 {
@@ -99,13 +101,18 @@ bool Task::startHook()
 
     m_status_query_deadline = base::Time();
     m_feedback_deadline = base::Time::now() + m_feedback_timeout;
-
+    m_input_deadline = base::Time::now() + m_input_timeout;
     return true;
 }
 void Task::updateHook()
 {
     if (base::Time::now() > m_feedback_deadline) {
         return exception(FEEDBACK_TIMEOUT);
+    }
+
+    if (base::Time::now() > m_input_deadline && state() != INPUT_TIMEOUT) {
+        writeSDOs(m_driver->queryMotorStop());
+        state(INPUT_TIMEOUT);
     }
 
     canbus::Message msg;
@@ -152,6 +159,11 @@ void Task::updateHook()
         m_driver->setJointCommand(command);
         auto const& messages = m_driver->queryJointCommandDownload();
         writeSDOs(messages);
+
+        m_input_deadline = base::Time::now() + m_input_timeout;
+        if (state() == INPUT_TIMEOUT) {
+            state(RUNNING);
+        }
     }
 
     TaskBase::updateHook();

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -7,15 +7,18 @@ using namespace std;
 using namespace motors_roboteq_canopen;
 
 Task::Task(std::string const& name)
-    : TaskBase(name) {
+    : TaskBase(name)
+{
     _status_query_period.set(base::Time::fromSeconds(5));
     _feedback_timeout.set(base::Time::fromSeconds(1));
 }
 
-Task::~Task() {
+Task::~Task()
+{
 }
 
-bool Task::configureHook() {
+bool Task::configureHook()
+{
     delete m_driver;
     m_driver = nullptr;
     delete m_state_machine;
@@ -33,7 +36,7 @@ bool Task::configureHook() {
     m_slave = m_driver;
     m_joint_state.elements.resize(channel_count);
 
-    if (! TaskBase::configureHook()) {
+    if (!TaskBase::configureHook()) {
         return false;
     }
 
@@ -48,12 +51,12 @@ bool Task::configureHook() {
     _can_out.write(m_slave->queryNodeStateTransition(canopen_master::NODE_RESET));
     usleep(1000000);
     toNMTState(canopen_master::NODE_PRE_OPERATIONAL,
-               canopen_master::NODE_ENTER_PRE_OPERATIONAL,
-               base::Time::fromMilliseconds(100));
+        canopen_master::NODE_ENTER_PRE_OPERATIONAL,
+        base::Time::fromMilliseconds(100));
 
     toNMTState(canopen_master::NODE_OPERATIONAL,
-               canopen_master::NODE_START,
-               base::Time::fromMilliseconds(100));
+        canopen_master::NODE_START,
+        base::Time::fromMilliseconds(100));
 
     writeSDOs(m_driver->queryMotorStop());
 
@@ -76,8 +79,10 @@ bool Task::configureHook() {
     m_analog_inputs.resize(analog_input_conf.size());
 
     vector<canbus::Message> tpdo_setup;
-    int pdoIndex = m_driver->setupJointStateTPDOs(tpdo_setup, 0, _joint_state_settings.get());
-    pdoIndex = m_driver->setupAnalogTPDOs(tpdo_setup, pdoIndex, _analog_input_settings.get());
+    int pdoIndex =
+        m_driver->setupJointStateTPDOs(tpdo_setup, 0, _joint_state_settings.get());
+    pdoIndex =
+        m_driver->setupAnalogTPDOs(tpdo_setup, pdoIndex, _analog_input_settings.get());
     if (_status_use_pdo.get()) {
         m_driver->setupStatusTPDOs(tpdo_setup, pdoIndex, _status_settings.get());
     }
@@ -88,7 +93,7 @@ bool Task::configureHook() {
 }
 bool Task::startHook()
 {
-    if (! TaskBase::startHook()) {
+    if (!TaskBase::startHook()) {
         return false;
     }
 
@@ -152,7 +157,8 @@ void Task::updateHook()
     TaskBase::updateHook();
 }
 
-void Task::handleStatusQuery() {
+void Task::handleStatusQuery()
+{
     if (m_status_sdos.empty()) {
         if (m_status_query_deadline > base::Time::now()) {
             return;
@@ -171,15 +177,17 @@ void Task::handleStatusQuery() {
     }
 }
 
-void Task::writeStatusPort() {
+void Task::writeStatusPort()
+{
     try {
         _controller_status.write(m_driver->getControllerStatus());
     }
-    catch(canopen_master::ObjectNotRead&) {
+    catch (canopen_master::ObjectNotRead&) {
     }
 }
 
-void Task::outputAnalog() {
+void Task::outputAnalog()
+{
     base::Time now = base::Time::now();
 
     auto const& conf = _analog_input_configuration.get();

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -47,6 +47,9 @@ namespace motors_roboteq_canopen{
         base::Time m_status_query_deadline;
         std::vector<canbus::Message> m_status_sdos;
 
+        base::Time m_input_deadline;
+        base::Time m_input_timeout;
+
         void handleStatusQuery();
         void writeStatusPort();
 


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
When there is no input commands, the controller enters in the INPUT_TIMEOUT exception state, so it can transition to stopHook and issue the stop command

The changes commit that really should be reviewed is 3b50040


# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
