### PR TITLE
fix: reduce period to 0.01 to fix Tupan

### DIFF
--- a/motors_roboteq_canopen.orogen
+++ b/motors_roboteq_canopen.orogen
@@ -72,7 +72,7 @@ task_context "Task", subclasses: "canopen_master::SlaveTask" do
     runtime_states "INPUT_TIMEOUT"
     exception_states :FEEDBACK_TIMEOUT
 
-    periodic 0.1
+    periodic 0.01
 end
 
 # Controller driver that uses the DS402 profile


### PR DESCRIPTION
A previous pull request modified the trigger method of the component from port_driven to periodic @ 100ms. This broke systems that needed a lower control period (i.e. steering on Tupan)

Changing to period 0.01 reduces that lower bound to 10ms. From a reading of the code, it defines a lower bound but a system that was (with port_driven) controlling at 100ms would still control at 100ms.

I think merging this PR is therefore resonable until we get the timeout on port_driven tested and merged.