### PR TITLE
feat: implement a multiplexer for digital outs in roboteqs

### DIFF
--- a/motors_roboteq_canopen.orogen
+++ b/motors_roboteq_canopen.orogen
@@ -123,3 +123,14 @@ task_context "DS402Task", subclasses: "canopen_master::SlaveTask" do
 
     port_driven :can_in, :joint_cmd
 end
+
+task_context "DigitalOutMultiplexerTask" do
+    needs_configuration
+
+    input_port "clutch_command", "/linux_gpios/GPIOState"
+    input_port "controller_selection_command", "/linux_gpios/GPIOState"
+
+    output_port "digital_out_command", "/linux_gpios/GPIOState"
+
+    port_driven
+end

--- a/motors_roboteq_canopenTypes.hpp
+++ b/motors_roboteq_canopenTypes.hpp
@@ -1,8 +1,8 @@
 #ifndef motors_roboteq_canopen_TYPES_HPP
 #define motors_roboteq_canopen_TYPES_HPP
 
-#include <motors_roboteq_canopen/Objects.hpp>
 #include <motors_roboteq_canopen/Factors.hpp>
+#include <motors_roboteq_canopen/Objects.hpp>
 
 namespace motors_roboteq_canopen {
     /** Configuration for a single channel
@@ -34,4 +34,3 @@ namespace motors_roboteq_canopen {
 }
 
 #endif
-

--- a/tasks/DigitalOutMultiplexerTask.cpp
+++ b/tasks/DigitalOutMultiplexerTask.cpp
@@ -1,0 +1,83 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "DigitalOutMultiplexerTask.hpp"
+#include "base-logging/Logging.hpp"
+#include "base/Time.hpp"
+#include "linux_gpios/linux_gpiosTypes.hpp"
+
+using namespace linux_gpios;
+using namespace motors_roboteq_canopen;
+using namespace std;
+
+DigitalOutMultiplexerTask::DigitalOutMultiplexerTask(std::string const& name)
+    : DigitalOutMultiplexerTaskBase(name)
+{
+}
+
+DigitalOutMultiplexerTask::~DigitalOutMultiplexerTask()
+{
+}
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See DigitalOutMultiplexerTask.hpp for more detailed
+// documentation about them.
+
+bool DigitalOutMultiplexerTask::configureHook()
+{
+    if (!DigitalOutMultiplexerTaskBase::configureHook())
+        return false;
+    return true;
+}
+
+bool DigitalOutMultiplexerTask::startHook()
+{
+    if (!DigitalOutMultiplexerTaskBase::startHook())
+        return false;
+    return true;
+}
+
+void DigitalOutMultiplexerTask::updateHook()
+{
+    DigitalOutMultiplexerTaskBase::updateHook();
+
+    GPIOState overall_command;
+    overall_command.states.resize(2);
+
+    GPIOState clutch_cmd;
+    if (_clutch_command.read(clutch_cmd) == RTT::NewData) {
+        if (clutch_cmd.states.size() != 1) {
+            throw runtime_error("clutch command must have a single state, but it has " +
+                                clutch_cmd.states.size());
+        }
+
+        overall_command.states[0] = clutch_cmd.states.front();
+    }
+    GPIOState controller_selection_cmd;
+    if (_controller_selection_command.read(controller_selection_cmd) == RTT::NewData) {
+        if (controller_selection_cmd.states.size() != 1) {
+            throw runtime_error(
+                "controller selection command must have a single state, but it has " +
+                controller_selection_cmd.states.size());
+        }
+
+        overall_command.states[1] = controller_selection_cmd.states.front();
+    }
+
+    overall_command.time = base::Time::now();
+    _digital_out_command.write(overall_command);
+}
+
+void DigitalOutMultiplexerTask::errorHook()
+{
+    DigitalOutMultiplexerTaskBase::errorHook();
+}
+
+void DigitalOutMultiplexerTask::stopHook()
+{
+    DigitalOutMultiplexerTaskBase::stopHook();
+}
+
+void DigitalOutMultiplexerTask::cleanupHook()
+{
+    DigitalOutMultiplexerTaskBase::cleanupHook();
+}

--- a/tasks/DigitalOutMultiplexerTask.hpp
+++ b/tasks/DigitalOutMultiplexerTask.hpp
@@ -1,0 +1,107 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef MOTORS_ROBOTEQ_CANOPEN_DIGITALOUTMULTIPLEXERTASK_TASK_HPP
+#define MOTORS_ROBOTEQ_CANOPEN_DIGITALOUTMULTIPLEXERTASK_TASK_HPP
+
+#include "motors_roboteq_canopen/DigitalOutMultiplexerTaskBase.hpp"
+#include <optional>
+
+namespace motors_roboteq_canopen {
+
+    /*! \class DigitalOutMultiplexerTask
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
+     *
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','motors_roboteq_canopen::DigitalOutMultiplexerTask')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
+     */
+    class DigitalOutMultiplexerTask : public DigitalOutMultiplexerTaskBase {
+        friend class DigitalOutMultiplexerTaskBase;
+
+    protected:
+    public:
+        /** TaskContext constructor for DigitalOutMultiplexerTask
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
+         */
+        DigitalOutMultiplexerTask(
+            std::string const& name =
+                "motors_roboteq_canopen::DigitalOutMultiplexerTask");
+
+        /** Default deconstructor of DigitalOutMultiplexerTask
+         */
+        ~DigitalOutMultiplexerTask();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif

--- a/test/DigitalOutMultiplexerTask_test.rb
+++ b/test/DigitalOutMultiplexerTask_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+using_task_library "motors_roboteq_canopen"
+
+describe OroGen.motors_roboteq_canopen.DigitalOutMultiplexerTask do
+    run_live
+
+    attr_reader :task
+
+    before do
+        @task = syskit_deploy(
+            OroGen.motors_roboteq_canopen.DigitalOutMultiplexerTask
+                  .deployed_as("task_under_test")
+        )
+    end
+
+    it "writes the clutch and controller selection commands in the right index" do
+        t = syskit_configure_and_start(@task)
+
+        clutch_cmd =
+            Types.linux_gpios.GPIOState.new(states: [Types.raw_io.Digital.new(data: 1)])
+        controller_selection_cmd =
+            Types.linux_gpios.GPIOState.new(states: [Types.raw_io.Digital.new(data: 0)])
+        time_before = Time.now
+        expect_execution do
+            syskit_write t.clutch_command_port, clutch_cmd
+            syskit_write t.controller_selection_command_port, controller_selection_cmd
+        end.to do
+            have_one_new_sample(t.digital_out_command_port).matching do |cmd|
+                assert_operator cmd.time, :>, time_before
+                assert_operator Time.now, :>, cmd.time
+                assert_equal cmd.states[0].data, 1
+                assert_equal cmd.states[1].data, 0
+            end
+        end
+    end
+
+    it "raises an exception when the clutch command doesnt have the expected size" do
+        t = syskit_configure_and_start(@task)
+
+        clutch_cmd =
+            Types.linux_gpios.GPIOState.new(states: [])
+        controller_selection_cmd =
+            Types.linux_gpios.GPIOState.new(states: [Types.raw_io.Digital.new(data: 0)])
+        expect_execution do
+            syskit_write t.clutch_command_port, clutch_cmd
+            syskit_write t.controller_selection_command_port, controller_selection_cmd
+        end.to do
+            emit t.exception_event
+        end
+    end
+
+    it "raises an exception when the controller_selection command doesnt have the " \
+       "expected size" do
+        t = syskit_configure_and_start(@task)
+
+        clutch_cmd =
+            Types.linux_gpios.GPIOState.new(states: [Types.raw_io.Digital.new(data: 1)])
+        controller_selection_cmd =
+            Types.linux_gpios.GPIOState.new(states: [])
+        expect_execution do
+            syskit_write t.clutch_command_port, clutch_cmd
+            syskit_write t.controller_selection_command_port, controller_selection_cmd
+        end.to do
+            emit t.exception_event
+        end
+    end
+end


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-drivers/drivers-raw_io/pull/1

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
I created the list of supported features to deal with the "ordering" issue when populating the out gpio state. The idea is to follow the order that is presented in the orogenconf. 


# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
