### PR TITLE
fix: Add the joint state sources as part of channel configuration

### DIFF
--- a/motors_roboteq_canopenTypes.hpp
+++ b/motors_roboteq_canopenTypes.hpp
@@ -1,8 +1,9 @@
 #ifndef motors_roboteq_canopen_TYPES_HPP
 #define motors_roboteq_canopen_TYPES_HPP
 
-#include <motors_roboteq_canopen/Objects.hpp>
 #include <motors_roboteq_canopen/Factors.hpp>
+#include <motors_roboteq_canopen/Objects.hpp>
+#include <motors_roboteq_canopen/JointStatePositionSources.hpp>
 
 namespace motors_roboteq_canopen {
     /** Configuration for a single channel
@@ -11,6 +12,8 @@ namespace motors_roboteq_canopen {
      */
     struct ChannelConfiguration {
         ControlModes control_mode = CONTROL_NONE;
+        JointStatePositionSources joint_state_position_source =
+            JOINT_STATE_POSITION_SOURCE_AUTO;
         Factors factors;
     };
 
@@ -34,4 +37,3 @@ namespace motors_roboteq_canopen {
 }
 
 #endif
-

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -67,6 +67,7 @@ bool Task::configureHook()
         ChannelConfiguration const& config = channel_configurations[i];
         channel.setControlMode(config.control_mode);
         channel.setFactors(config.factors);
+        channel.setJointStatePositionSource(config.joint_state_position_source);
     }
 
     auto analog_input_conf = _analog_input_configuration.get();


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-motors_roboteq_canopen/pull/12

# What is this PR for
[sc-74445]

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
